### PR TITLE
Added UIApplicationDidBecomeActiveNotification observer

### DIFF
--- a/src/ios/AppDelegate+privacyscreen.m
+++ b/src/ios/AppDelegate+privacyscreen.m
@@ -11,13 +11,22 @@ UIImageView *imageView;
 
 @implementation AppDelegate (privacyscreen)
 
+
+// Method only seems to be called on iPad Pro
 - (void)applicationDidBecomeActive:(UIApplication *)application
+{
+  [self applicationWakes];
+}
+
+- (void)applicationWakes
 {
   if (imageView == NULL) {
     self.window.hidden = NO;
   } else {
     [imageView removeFromSuperview];
   }
+
+  [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidBecomeActiveNotification object:nil];
 }
 
 - (void)applicationWillResignActive:(UIApplication *)application
@@ -31,6 +40,9 @@ UIImageView *imageView;
     [imageView setImage:splash];
     [self.viewController.view addSubview:imageView];
   }
+
+  // ApplicationDidBecomeActive needs to be observed, without the observer the method will not be called
+  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationWakes) name:UIApplicationDidBecomeActiveNotification object:nil];
 }
 
 // Code below borrowed from the CDV splashscreen plugin @ https://github.com/apache/cordova-plugin-splashscreen
@@ -38,13 +50,13 @@ UIImageView *imageView;
 - (CDV_iOSDevice) getCurrentDevice
 {
   CDV_iOSDevice device;
-  
+
   UIScreen* mainScreen = [UIScreen mainScreen];
   CGFloat mainScreenHeight = mainScreen.bounds.size.height;
   CGFloat mainScreenWidth = mainScreen.bounds.size.width;
-  
+
   int limit = MAX(mainScreenHeight,mainScreenWidth);
-  
+
   device.iPad = (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad);
   device.iPhone = (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone);
   device.retina = ([mainScreen scale] == 2.0);
@@ -54,7 +66,7 @@ UIImageView *imageView;
   // this is appropriate for detecting the runtime screen environment
   device.iPhone6 = (device.iPhone && limit == 667.0);
   device.iPhone6Plus = (device.iPhone && limit == 736.0);
-  
+
   return device;
 }
 
@@ -62,24 +74,24 @@ UIImageView *imageView;
 {
   // Use UILaunchImageFile if specified in plist.  Otherwise, use Default.
   NSString* imageName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UILaunchImageFile"];
-  
+
   NSUInteger supportedOrientations = [orientationDelegate supportedInterfaceOrientations];
-  
+
   // Checks to see if the developer has locked the orientation to use only one of Portrait or Landscape
   BOOL supportsLandscape = (supportedOrientations & UIInterfaceOrientationMaskLandscape);
   BOOL supportsPortrait = (supportedOrientations & UIInterfaceOrientationMaskPortrait || supportedOrientations & UIInterfaceOrientationMaskPortraitUpsideDown);
   // this means there are no mixed orientations in there
   BOOL isOrientationLocked = !(supportsPortrait && supportsLandscape);
-  
+
   if (imageName) {
     imageName = [imageName stringByDeletingPathExtension];
   } else {
     imageName = @"Default";
   }
-  
+
   BOOL isLandscape = supportsLandscape &&
   (currentOrientation == UIInterfaceOrientationLandscapeLeft || currentOrientation == UIInterfaceOrientationLandscapeRight);
-  
+
   if (device.iPhone5) { // does not support landscape
     imageName = isLandscape ? nil : [imageName stringByAppendingString:@"-568h"];
   } else if (device.iPhone6) { // does not support landscape
@@ -98,7 +110,7 @@ UIImageView *imageView;
       }
     }
     imageName = [imageName stringByAppendingString:@"-736h"];
-    
+
   } else if (device.iPad) { // supports landscape
     if (isOrientationLocked) {
       imageName = [imageName stringByAppendingString:(supportsLandscape ? @"-Landscape" : @"-Portrait")];
@@ -108,7 +120,7 @@ UIImageView *imageView;
         case UIInterfaceOrientationLandscapeRight:
           imageName = [imageName stringByAppendingString:@"-Landscape"];
           break;
-          
+
         case UIInterfaceOrientationPortrait:
         case UIInterfaceOrientationPortraitUpsideDown:
         default:
@@ -117,7 +129,7 @@ UIImageView *imageView;
       }
     }
   }
-  
+
   return imageName;
 }
 


### PR DESCRIPTION
Method ```applicationDidBecomeActive``` only got called on iPad Pro, did not work on iPad Mini and iPad 4.
The added observer will make sure the plugin will acknowledge the application wake.