### PR TITLE
Switching back to app does not hide splash screen

### DIFF
--- a/src/ios/AppDelegate+privacyscreen.h
+++ b/src/ios/AppDelegate+privacyscreen.h
@@ -13,11 +13,12 @@ typedef struct {
   BOOL iPhone6;
   BOOL iPhone6Plus;
   BOOL retina;
-  
+
 } CDV_iOSDevice;
 
 @interface AppDelegate (privacyscreen)
-- (void)applicationWillResignActive:(UIApplication *)application;
-- (void)applicationDidBecomeActive:(UIApplication *)application;
+
+- (void)privacyScreenOnApplicationDidBecomeActive:(NSNotification *)notification;
+- (void)privacyScreenOnApplicationWillResignActive:(NSNotification *)notification;
 
 @end


### PR DESCRIPTION
Fixes #12

Seems the plugin was not swizzling AppDelegate, but simply overriding
it.

This means it all worked fine and dandy as long as no other plugins were
overriding or swizzling AppDelegates applicationWillResignActive or
applicationDidBecomeActive.

Sadly, phonegap-plugin-push and many more do exactly this... so the
combination was causing one or both plugins to fail.

This change fixes the swizzling in this plugin, making it play nicely
with phonegap-plugin-push, and hopefully others.

Coincidentally, phonegap-plugin-push was also incorrectly overriding
applicationDidBecomeActive, so I have sent a PR to correct
phonegap-plugin-push as well.