### PR TITLE
added missing asset prefixes for cordova-ios4

### DIFF
--- a/src/ios/PrivacyScreenPlugin.h
+++ b/src/ios/PrivacyScreenPlugin.h
@@ -10,6 +10,7 @@
 typedef struct {
   BOOL iPhone;
   BOOL iPad;
+  BOOL iPhone4;
   BOOL iPhone5;
   BOOL iPhone6;
   BOOL iPhone6Plus;

--- a/src/ios/PrivacyScreenPlugin.m
+++ b/src/ios/PrivacyScreenPlugin.m
@@ -38,7 +38,7 @@ UIImageView *imageView;
   } else {
     imageView = [[UIImageView alloc]initWithFrame:[self.viewController.view bounds]];
     [imageView setImage:splash];
-    [self.viewController.view addSubview:imageView];
+    [[UIApplication sharedApplication].keyWindow addSubview:imageView];
   }
 }
 

--- a/src/ios/PrivacyScreenPlugin.m
+++ b/src/ios/PrivacyScreenPlugin.m
@@ -57,6 +57,7 @@ UIImageView *imageView;
   device.iPad = (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad);
   device.iPhone = (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone);
   device.retina = ([mainScreen scale] == 2.0);
+  device.iPhone4 = (device.iPhone && limit == 480.0);
   device.iPhone5 = (device.iPhone && limit == 568.0);
   // note these below is not a true device detect, for example if you are on an
   // iPhone 6/6+ but the app is scaled it will prob set iPhone5 as true, but
@@ -84,6 +85,21 @@ UIImageView *imageView;
     imageName = [imageName stringByDeletingPathExtension];
   } else {
     imageName = @"Default";
+  }
+
+  // Add Asset Catalog specific prefixes
+  if ([imageName isEqualToString:@"LaunchImage"])
+  {
+    if(device.iPhone4 || device.iPhone5 || device.iPad) {
+      imageName = [imageName stringByAppendingString:@"-700"];
+    } else if(device.iPhone6) {
+      imageName = [imageName stringByAppendingString:@"-800"];
+    } else if(device.iPhone6Plus) {
+      imageName = [imageName stringByAppendingString:@"-800"];
+      if (currentOrientation == UIInterfaceOrientationPortrait || currentOrientation == UIInterfaceOrientationPortraitUpsideDown) {
+        imageName = [imageName stringByAppendingString:@"-Portrait"];
+      }
+    }
   }
   
   BOOL isLandscape = supportsLandscape &&

--- a/src/ios/PrivacyScreenPlugin.m
+++ b/src/ios/PrivacyScreenPlugin.m
@@ -38,7 +38,7 @@ UIImageView *imageView;
   } else {
     imageView = [[UIImageView alloc]initWithFrame:[self.viewController.view bounds]];
     [imageView setImage:splash];
-    [[UIApplication sharedApplication].keyWindow addSubview:imageView];
+    [self.viewController.view addSubview:imageView];
   }
 }
 


### PR DESCRIPTION
The Splashscreen was not being found any more on iOS9, therefore I added the prefixes as was done in https://github.com/apache/cordova-plugin-splashscreen.
Also added iPhone4 support.

I tested this on iPhone 6 and 6+ (iOS9) and iPhone 4s (iOS8) with cordova 6.1.1 and cordova-ios 4.1.1.