### PR TITLE
Compatibility with other Overlay-Plugins on iOS

### DIFF
--- a/src/ios/PrivacyScreenPlugin.m
+++ b/src/ios/PrivacyScreenPlugin.m
@@ -38,7 +38,7 @@ UIImageView *imageView;
   } else {
     imageView = [[UIImageView alloc]initWithFrame:[self.viewController.view bounds]];
     [imageView setImage:splash];
-    [self.viewController.view addSubview:imageView];
+    [[UIApplication sharedApplication].keyWindow addSubview:imageView];
   }
 }
 

--- a/src/ios/PrivacyScreenPlugin.m
+++ b/src/ios/PrivacyScreenPlugin.m
@@ -38,7 +38,12 @@ UIImageView *imageView;
   } else {
     imageView = [[UIImageView alloc]initWithFrame:[self.viewController.view bounds]];
     [imageView setImage:splash];
-    [[UIApplication sharedApplication].keyWindow addSubview:imageView];
+    
+    #ifdef __CORDOVA_4_0_0
+        [[UIApplication sharedApplication].keyWindow addSubview:imageView];
+    #else
+        [self.viewController.view addSubview:imageView];
+    #endif
   }
 }
 


### PR DESCRIPTION
I recently discovered that the Overlay was not being shown when a different Overlay was currently being displayed in the App (InAppBrowser for example). Using sharedApplication.keyWindow ensures that it's being added to the currently displayed view.