### PR TITLE
make imageView static to avoid conflict

### DIFF
--- a/src/ios/PrivacyScreenPlugin.m
+++ b/src/ios/PrivacyScreenPlugin.m
@@ -6,7 +6,7 @@
  */
 #import "PrivacyScreenPlugin.h"
 
-UIImageView *imageView;
+static UIImageView *imageView;
 
 @implementation PrivacyScreenPlugin
 


### PR DESCRIPTION
The imageview variable defined in PrivacyScreenPlugin.m should not exist in global scope to avoid conflict with other files.