### PR TITLE
Added functionality to enable or disable the PrivacyScreen

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -4,28 +4,33 @@
 	<name>PrivacyScreenPlugin</name>
 	<description>Secures your app from displaying a screenshot in task switchers under Android and iOS. Keeps sensitive information private.</description>
 	<license>MIT</license>
-	<platform name="android">
 
-    <config-file parent="/*" target="res/xml/config.xml">
-      <feature name="PrivacyScreenPlugin">
-        <param name="android-package" value="org.devgeeks.privacyscreen.PrivacyScreenPlugin"/>
-        <param name="onload" value="true" />
-      </feature>
-    </config-file>
+    <js-module src="www/PrivacyScreenPlugin.js" name="privacyscreen">
+        <clobbers target="window.PrivacyScreen" />
+    </js-module>
+
+	<platform name="android">
+        <config-file parent="/*" target="res/xml/config.xml">
+          <feature name="PrivacyScreenPlugin">
+            <param name="android-package" value="org.devgeeks.privacyscreen.PrivacyScreenPlugin"/>
+            <param name="onload" value="true" />
+          </feature>
+        </config-file>
 
 		<source-file src="src/android/PrivacyScreenPlugin.java" target-dir="src/org/devgeeks/privacyscreen"/>
 	</platform>
 
 	<platform name="ios">
+        <config-file parent="/*" target="config.xml">
+          <feature name="PrivacyScreenPlugin">
+            <param name="ios-package" value="PrivacyScreenPlugin"/>
+            <param name="onload" value="true" />
+          </feature>
+          <preference name="PrivacyScreenEnabled" value="true" />
+        </config-file>
 
-    <config-file parent="/*" target="config.xml">
-      <feature name="PrivacyScreenPlugin">
-        <param name="ios-package" value="PrivacyScreenPlugin"/>
-        <param name="onload" value="true" />
-      </feature>
-    </config-file>
-
-		<source-file src="src/ios/PrivacyScreenPlugin.h"/>
-		<source-file src="src/ios/PrivacyScreenPlugin.m"/>
+        <source-file src="src/ios/PrivacyScreenPlugin.h"/>
+        <source-file src="src/ios/PrivacyScreenPlugin.m"/>
 	</platform>
+
 </plugin>

--- a/src/ios/PrivacyScreenPlugin.h
+++ b/src/ios/PrivacyScreenPlugin.h
@@ -18,6 +18,13 @@ typedef struct {
   
 } CDV_iOSDevice;
 
-@interface PrivacyScreenPlugin : CDVPlugin
+@interface PrivacyScreenPlugin : CDVPlugin {
+    @protected
+    BOOL _privacyScreenEnabled;
+}
+
+@property (readwrite, assign) BOOL privacyScreenEnabled;
+
+- (void)enabled:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/src/ios/PrivacyScreenPlugin.m
+++ b/src/ios/PrivacyScreenPlugin.m
@@ -10,8 +10,17 @@ static UIImageView *imageView;
 
 @implementation PrivacyScreenPlugin
 
+- (id)settingForKey:(NSString*)key
+{
+    return [self.commandDelegate.settings objectForKey:[key lowercaseString]];
+}
+
 - (void)pluginInitialize
 {
+  if ([self settingForKey:@"PrivacyScreenEnabled"]) {
+      self.privacyScreenEnabled = [(NSNumber*)[self settingForKey:@"PrivacyScreenEnabled"] boolValue];
+  }
+
   [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onAppDidBecomeActive:)
                                                name:UIApplicationDidBecomeActiveNotification object:nil];
 
@@ -30,6 +39,10 @@ static UIImageView *imageView;
 
 - (void)onAppWillResignActive:(UIApplication *)application
 {
+  if (!_privacyScreenEnabled) {
+    return;
+  }
+
   CDVViewController *vc = (CDVViewController*)self.viewController;
   NSString *imgName = [self getImageName:self.viewController.interfaceOrientation delegate:(id<CDVScreenOrientationDelegate>)vc device:[self getCurrentDevice]];
   UIImage *splash = [UIImage imageNamed:imgName];
@@ -149,6 +162,16 @@ static UIImageView *imageView;
   }
   
   return imageName;
+}
+
+- (void)enabled:(CDVInvokedUrlCommand*)command
+{
+    id value = [command.arguments objectAtIndex:0];
+    if (!([value isKindOfClass:[NSNumber class]])) {
+        value = [NSNumber numberWithBool:NO];
+    }
+
+    self.privacyScreenEnabled = [value boolValue];
 }
 
 @end

--- a/www/PrivacyScreenPlugin.js
+++ b/www/PrivacyScreenPlugin.js
@@ -1,8 +1,10 @@
-//var exec = require('cordova/exec');
+var exec = require('cordova/exec');
 
-/** 
- * Not sure this will even have a JS API
- */
-//exports.activate = function(arg, success, error) {
-  //exec(success, error, "PrivacyScreenPlugin", "activate", [arg]);
-//};
+
+var PrivacyScreen = function () {};
+
+PrivacyScreen.enabled = function(enabled) {
+    exec(null, null, "PrivacyScreenPlugin", "enabled", [enabled]);
+};
+
+module.exports = PrivacyScreen;


### PR DESCRIPTION
Default value is true but can be changed with a config preference.

Use case example: disable the PrivacyScreen when the native Touch ID popup opens.