### PR TITLE
reset imageView to avoid black screen when activating the app

### DIFF
--- a/src/ios/PrivacyScreenPlugin.m
+++ b/src/ios/PrivacyScreenPlugin.m
@@ -34,6 +34,7 @@ static UIImageView *imageView;
   NSString *imgName = [self getImageName:self.viewController.interfaceOrientation delegate:(id<CDVScreenOrientationDelegate>)vc device:[self getCurrentDevice]];
   UIImage *splash = [UIImage imageNamed:imgName];
   if (splash == NULL) {
+    imageView = NULL;
     self.viewController.view.window.hidden = YES;
   } else {
     imageView = [[UIImageView alloc]initWithFrame:[self.viewController.view bounds]];


### PR DESCRIPTION
In applicationWillResignActive method, when splash is null, it will hide the main windows. But at that time, the imageView may already be set to some value left over by previous operation.  So when the app is activated later, the main window may not show by checking the condition of f (imageView == NULL) 

The issue can be repeated in the following scenario:
1. in ios project, the application only splash image for portrait mode.
2. after launching the app, first put the app in background and then activate again, imageView will be set to a valid image for portrait mode.
3. then rotate the device to landscape mode, and put the app in background, as no landscape image available, so 
  if (splash == NULL) {   
      self.window.hidden = YES;
}
is called by applicationWillResignActive method.
4. Activate the app again, as imageView is already set to a valid object in step 2, so it will skip the call of 
  if (imageView == NULL) {
    self.window.hidden = NO;
  } 
in applicationDidBecomeActive method. 
5. As a result, the main window is still hidden, and a black screen shows after the application is activated again.

To fix the issue, need to reset imageView to null if splash image is not available.