### PR TITLE
Do not show privacy screen when app is in foreground while inactive

### DIFF
--- a/src/ios/PrivacyScreenPlugin.m
+++ b/src/ios/PrivacyScreenPlugin.m
@@ -12,14 +12,14 @@ static UIImageView *imageView;
 
 - (void)pluginInitialize
 {
-  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onAppDidBecomeActive:)
-                                               name:UIApplicationDidBecomeActiveNotification object:nil];
+  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onAppWillEnterForeground:)
+                                           name:UIApplicationWillEnterForegroundNotification object:nil];
 
-  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onAppWillResignActive:)
-                                               name:UIApplicationWillResignActiveNotification object:nil];
+  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onAppDidEnterBackground:)
+                                           name:UIApplicationDidEnterBackgroundNotification object:nil];
 }
 
-- (void)onAppDidBecomeActive:(UIApplication *)application
+- (void)onAppWillEnterForeground:(UIApplication *)application
 {
   if (imageView == NULL) {
     self.viewController.view.window.hidden = NO;
@@ -28,7 +28,7 @@ static UIImageView *imageView;
   }
 }
 
-- (void)onAppWillResignActive:(UIApplication *)application
+- (void)onAppDidEnterBackground:(UIApplication *)application
 {
   CDVViewController *vc = (CDVViewController*)self.viewController;
   NSString *imgName = [self getImageName:self.viewController.interfaceOrientation delegate:(id<CDVScreenOrientationDelegate>)vc device:[self getCurrentDevice]];


### PR DESCRIPTION
Hi,
This change is for not showing privacy screen when the app is still in foreground but may temporarily inactive, for example, when showing the ios native touch id dialog, or when user using splitview slide, or when sliding from top to show the device status bar.

I saw there is already another pull request for this issue, https://github.com/devgeeks/PrivacyScreenPlugin/pull/26
but think that pull request may cause some side effect, so would suggest to fix the issue by changing the privacy plugin's notification handler from

UIApplicationDidBecomeActiveNotification
UIApplicationWillResignActiveNotification 
to
UIApplicationWillEnterForegroundNotification
UIApplicationDidEnterBackgroundNotification

This also follows better with Apple's UI guide, as when the app is still in foreground, the app should still show the meaningful content to user.

Thanks
Jonathan