### PR TITLE
Fix warning for PrivacyScreenPlugin.h header-file specified as source-file

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -25,7 +25,7 @@
       </feature>
     </config-file>
 
-		<source-file src="src/ios/PrivacyScreenPlugin.h"/>
+		<header-file src="src/ios/PrivacyScreenPlugin.h"/>
 		<source-file src="src/ios/PrivacyScreenPlugin.m"/>
 	</platform>
 </plugin>


### PR DESCRIPTION
## Description
Fix the issue while Xcode compile the project `warning: no rule to process file '/IOS_PROJECT/Plugins/cordova-plugin-privacyscreen/PrivacyScreenPlugin.h' of type sourcecode.c.h for architecture xxx`

Due to specified the PrivacyScreenPlugin.h as source-file instead of header-file.
Change it to header-file will fix this issue

## Related Issue
#38 

## Motivation and Context
Just want to make things right, and one less issue while compiling my project.

## How Has This Been Tested?
Applied the fix, and `cordova plugin rm (the plugin)` then `cordova plugin add (the fixed plugin)` , then compile again. Warning no longer there.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
