### PR TITLE
(iOS) Added preferences for privacy on background only and overriding LaunchImage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Usage:
 
 This plugin exposes no interface, it simply sets your app to be private. You don't need to do anything except install the plugin.
 
+For iOS there are 2 preferences that can be set in config.xml:
+- "PrivacyOnBackground": If set to "true" allows splashscreen to be shown only when app enters background (i.e. switched to another app or pressed the home button)
+- "PrivacyOverrideLaunchImage": If set to "true" allows privacy screen to be the Default image even if LaunchImage is set in the info-plist
+ 
 Test this plugin on a real device because the iOS simulator (7.1 at least) does a poor job hiding your app.
 
 ## License

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-privacyscreen",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Secures your app from displaying a screenshot in task switchers under Android and iOS. Keeps sensitive information private.",
   "cordova": {
     "id": "cordova-plugin-privacyscreen",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-privacyscreen" version="0.3.1">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-privacyscreen" version="0.3.2">
 
 	<name>PrivacyScreenPlugin</name>
 	<description>Secures your app from displaying a screenshot in task switchers under Android and iOS. Keeps sensitive information private.</description>

--- a/src/ios/PrivacyScreenPlugin.m
+++ b/src/ios/PrivacyScreenPlugin.m
@@ -12,144 +12,155 @@ static UIImageView *imageView;
 
 - (void)pluginInitialize
 {
-  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onAppDidBecomeActive:)
-                                               name:UIApplicationDidBecomeActiveNotification object:nil];
-
-  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onAppWillResignActive:)
-                                               name:UIApplicationWillResignActiveNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onAppDidBecomeActive:)
+                                                 name:UIApplicationDidBecomeActiveNotification object:nil];
+    NSString* onBackgroundKey = @"privacyonbackground";
+    
+    if([self.commandDelegate.settings objectForKey:[onBackgroundKey lowercaseString]] && [[self.commandDelegate.settings objectForKey:[onBackgroundKey lowercaseString]] isEqualToString:@"true"])
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onAppWillResignActive:)
+                                                     name:UIApplicationDidEnterBackgroundNotification object:nil];
+    else
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onAppWillResignActive:)
+                                                     name:UIApplicationWillResignActiveNotification object:nil];
 }
 
 - (void)onAppDidBecomeActive:(UIApplication *)application
 {
-  if (imageView == NULL) {
-    self.viewController.view.window.hidden = NO;
-  } else {
-    [imageView removeFromSuperview];
-  }
+    if (imageView == NULL) {
+        self.viewController.view.window.hidden = NO;
+    } else {
+        [imageView removeFromSuperview];
+    }
 }
 
 - (void)onAppWillResignActive:(UIApplication *)application
 {
-  CDVViewController *vc = (CDVViewController*)self.viewController;
-  NSString *imgName = [self getImageName:self.viewController.interfaceOrientation delegate:(id<CDVScreenOrientationDelegate>)vc device:[self getCurrentDevice]];
-  UIImage *splash = [UIImage imageNamed:imgName];
-  if (splash == NULL) {
-    imageView = NULL;
-    self.viewController.view.window.hidden = YES;
-  } else {
-    imageView = [[UIImageView alloc]initWithFrame:[self.viewController.view bounds]];
-    [imageView setImage:splash];
-    
-    #ifdef __CORDOVA_4_0_0
+    CDVViewController *vc = (CDVViewController*)self.viewController;
+    NSString *imgName = [self getImageName:self.viewController.interfaceOrientation delegate:(id<CDVScreenOrientationDelegate>)vc device:[self getCurrentDevice]];
+    UIImage *splash = [UIImage imageNamed:imgName];
+    if (splash == NULL) {
+        imageView = NULL;
+        self.viewController.view.window.hidden = YES;
+    } else {
+        imageView = [[UIImageView alloc]initWithFrame:[self.viewController.view bounds]];
+        [imageView setImage:splash];
+        
+#ifdef __CORDOVA_4_0_0
         [[UIApplication sharedApplication].keyWindow addSubview:imageView];
-    #else
+#else
         [self.viewController.view addSubview:imageView];
-    #endif
-  }
+#endif
+    }
 }
 
 // Code below borrowed from the CDV splashscreen plugin @ https://github.com/apache/cordova-plugin-splashscreen
 // Made some adjustments though, becuase landscape splashscreens are not available for iphone < 6 plus
 - (CDV_iOSDevice) getCurrentDevice
 {
-  CDV_iOSDevice device;
-  
-  UIScreen* mainScreen = [UIScreen mainScreen];
-  CGFloat mainScreenHeight = mainScreen.bounds.size.height;
-  CGFloat mainScreenWidth = mainScreen.bounds.size.width;
-  
-  int limit = MAX(mainScreenHeight,mainScreenWidth);
-  
-  device.iPad = (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad);
-  device.iPhone = (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone);
-  device.retina = ([mainScreen scale] == 2.0);
-  device.iPhone4 = (device.iPhone && limit == 480.0);
-  device.iPhone5 = (device.iPhone && limit == 568.0);
-  // note these below is not a true device detect, for example if you are on an
-  // iPhone 6/6+ but the app is scaled it will prob set iPhone5 as true, but
-  // this is appropriate for detecting the runtime screen environment
-  device.iPhone6 = (device.iPhone && limit == 667.0);
-  device.iPhone6Plus = (device.iPhone && limit == 736.0);
-  
-  return device;
+    CDV_iOSDevice device;
+    
+    UIScreen* mainScreen = [UIScreen mainScreen];
+    CGFloat mainScreenHeight = mainScreen.bounds.size.height;
+    CGFloat mainScreenWidth = mainScreen.bounds.size.width;
+    
+    int limit = MAX(mainScreenHeight,mainScreenWidth);
+    
+    device.iPad = (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad);
+    device.iPhone = (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone);
+    device.retina = ([mainScreen scale] == 2.0);
+    device.iPhone4 = (device.iPhone && limit == 480.0);
+    device.iPhone5 = (device.iPhone && limit == 568.0);
+    // note these below is not a true device detect, for example if you are on an
+    // iPhone 6/6+ but the app is scaled it will prob set iPhone5 as true, but
+    // this is appropriate for detecting the runtime screen environment
+    device.iPhone6 = (device.iPhone && limit == 667.0);
+    device.iPhone6Plus = (device.iPhone && limit == 736.0);
+    
+    return device;
 }
 
 - (NSString*)getImageName:(UIInterfaceOrientation)currentOrientation delegate:(id<CDVScreenOrientationDelegate>)orientationDelegate device:(CDV_iOSDevice)device
 {
-  // Use UILaunchImageFile if specified in plist.  Otherwise, use Default.
-  NSString* imageName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UILaunchImageFile"];
-  
-  NSUInteger supportedOrientations = [orientationDelegate supportedInterfaceOrientations];
-  
-  // Checks to see if the developer has locked the orientation to use only one of Portrait or Landscape
-  BOOL supportsLandscape = (supportedOrientations & UIInterfaceOrientationMaskLandscape);
-  BOOL supportsPortrait = (supportedOrientations & UIInterfaceOrientationMaskPortrait || supportedOrientations & UIInterfaceOrientationMaskPortraitUpsideDown);
-  // this means there are no mixed orientations in there
-  BOOL isOrientationLocked = !(supportsPortrait && supportsLandscape);
-  
-  if (imageName) {
-    imageName = [imageName stringByDeletingPathExtension];
-  } else {
-    imageName = @"Default";
-  }
-
-  // Add Asset Catalog specific prefixes
-  if ([imageName isEqualToString:@"LaunchImage"])
-  {
-    if(device.iPhone4 || device.iPhone5 || device.iPad) {
-      imageName = [imageName stringByAppendingString:@"-700"];
-    } else if(device.iPhone6) {
-      imageName = [imageName stringByAppendingString:@"-800"];
-    } else if(device.iPhone6Plus) {
-      imageName = [imageName stringByAppendingString:@"-800"];
-      if (currentOrientation == UIInterfaceOrientationPortrait || currentOrientation == UIInterfaceOrientationPortraitUpsideDown) {
-        imageName = [imageName stringByAppendingString:@"-Portrait"];
-      }
+    NSString* imageName = @"Default";
+    //Override Launch images?
+    NSString* privacyOverrideLaunchImage = @"privacyoverridelaunchimage";
+    if([self.commandDelegate.settings objectForKey:[privacyOverrideLaunchImage lowercaseString]] && [[self.commandDelegate.settings objectForKey:[privacyOverrideLaunchImage lowercaseString]] isEqualToString:@"true"])
+    {
+        
     }
-  }
-  
-  BOOL isLandscape = supportsLandscape &&
-  (currentOrientation == UIInterfaceOrientationLandscapeLeft || currentOrientation == UIInterfaceOrientationLandscapeRight);
-  
-  if (device.iPhone5) { // does not support landscape
-    imageName = isLandscape ? nil : [imageName stringByAppendingString:@"-568h"];
-  } else if (device.iPhone6) { // does not support landscape
-    imageName = isLandscape ? nil : [imageName stringByAppendingString:@"-667h"];
-  } else if (device.iPhone6Plus) { // supports landscape
-    if (isOrientationLocked) {
-      imageName = [imageName stringByAppendingString:(supportsLandscape ? @"-Landscape" : @"")];
-    } else {
-      switch (currentOrientation) {
-        case UIInterfaceOrientationLandscapeLeft:
-        case UIInterfaceOrientationLandscapeRight:
-          imageName = [imageName stringByAppendingString:@"-Landscape"];
-          break;
-        default:
-          break;
-      }
+    else
+    {
+        // Use UILaunchImageFile if specified in plist.  Otherwise, use Default.
+        imageName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UILaunchImageFile"];
+        imageName = [imageName stringByDeletingPathExtension];
     }
-    imageName = [imageName stringByAppendingString:@"-736h"];
     
-  } else if (device.iPad) { // supports landscape
-    if (isOrientationLocked) {
-      imageName = [imageName stringByAppendingString:(supportsLandscape ? @"-Landscape" : @"-Portrait")];
-    } else {
-      switch (currentOrientation) {
-        case UIInterfaceOrientationLandscapeLeft:
-        case UIInterfaceOrientationLandscapeRight:
-          imageName = [imageName stringByAppendingString:@"-Landscape"];
-          break;
-          
-        case UIInterfaceOrientationPortrait:
-        case UIInterfaceOrientationPortraitUpsideDown:
-        default:
-          imageName = [imageName stringByAppendingString:@"-Portrait"];
-          break;
-      }
+    NSUInteger supportedOrientations = [orientationDelegate supportedInterfaceOrientations];
+    
+    // Checks to see if the developer has locked the orientation to use only one of Portrait or Landscape
+    BOOL supportsLandscape = (supportedOrientations & UIInterfaceOrientationMaskLandscape);
+    BOOL supportsPortrait = (supportedOrientations & UIInterfaceOrientationMaskPortrait || supportedOrientations & UIInterfaceOrientationMaskPortraitUpsideDown);
+    // this means there are no mixed orientations in there
+    BOOL isOrientationLocked = !(supportsPortrait && supportsLandscape);
+    
+    
+    // Add Asset Catalog specific prefixes
+    if ([imageName isEqualToString:@"LaunchImage"])
+    {
+        if(device.iPhone4 || device.iPhone5 || device.iPad) {
+            imageName = [imageName stringByAppendingString:@"-700"];
+        } else if(device.iPhone6) {
+            imageName = [imageName stringByAppendingString:@"-800"];
+        } else if(device.iPhone6Plus) {
+            imageName = [imageName stringByAppendingString:@"-800"];
+            if (currentOrientation == UIInterfaceOrientationPortrait || currentOrientation == UIInterfaceOrientationPortraitUpsideDown) {
+                imageName = [imageName stringByAppendingString:@"-Portrait"];
+            }
+        }
     }
-  }
-  
-  return imageName;
+    
+    BOOL isLandscape = supportsLandscape &&
+    (currentOrientation == UIInterfaceOrientationLandscapeLeft || currentOrientation == UIInterfaceOrientationLandscapeRight);
+    
+    if (device.iPhone5) { // does not support landscape
+        imageName = isLandscape ? nil : [imageName stringByAppendingString:@"-568h"];
+    } else if (device.iPhone6) { // does not support landscape
+        imageName = isLandscape ? nil : [imageName stringByAppendingString:@"-667h"];
+    } else if (device.iPhone6Plus) { // supports landscape
+        if (isOrientationLocked) {
+            imageName = [imageName stringByAppendingString:(supportsLandscape ? @"-Landscape" : @"")];
+        } else {
+            switch (currentOrientation) {
+                case UIInterfaceOrientationLandscapeLeft:
+                case UIInterfaceOrientationLandscapeRight:
+                    imageName = [imageName stringByAppendingString:@"-Landscape"];
+                    break;
+                default:
+                    break;
+            }
+        }
+        imageName = [imageName stringByAppendingString:@"-736h"];
+        
+    } else if (device.iPad) { // supports landscape
+        if (isOrientationLocked) {
+            imageName = [imageName stringByAppendingString:(supportsLandscape ? @"-Landscape" : @"-Portrait")];
+        } else {
+            switch (currentOrientation) {
+                case UIInterfaceOrientationLandscapeLeft:
+                case UIInterfaceOrientationLandscapeRight:
+                    imageName = [imageName stringByAppendingString:@"-Landscape"];
+                    break;
+                    
+                case UIInterfaceOrientationPortrait:
+                case UIInterfaceOrientationPortraitUpsideDown:
+                default:
+                    imageName = [imageName stringByAppendingString:@"-Portrait"];
+                    break;
+            }
+        }
+    }
+    
+    return imageName;
 }
 
 @end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In iOS activating privacy in WillResign method generates a behavior that isn't desirable in current project I'm working on (i.e. Shows privacy screen in Touch ID prompt), as such a preference "PrivacyOnBackground" is now checked, if it is true then privacy screen is only activated on background.
Another preference "PrivacyOverrideLaunchImage" has been added so that even if a launch image is set, if this preference is true it overrides to the "Default" image.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
On our app that uses this plugin, when the Touch Id Prompt was launched the privacy screen blocked the app view.
The app has a launch image, but it has been defined in our app that the privacy screen must be different

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual testing to check if intended behavior was added, manual testing to check if previous behavior was kept without changes to current users of the plugin.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [X ] My change requires a change to the documentation.
- [X ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
