### PR TITLE
Add basic functionality to use storyboard images on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-PrivacyScreenPlugin-Storyboard
+PrivacyScreenPlugin
 ==================
 
 Both iOS (as of iOS 7) and Android have app switchers that display a screenshot of your app.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Installation
 
 For Cordova 3.x.x:
 
-1. To add this plugin just type: `cordova plugin add cordova-plugin-privacyscreen` or `phonegap local plugin add cordova-plugin-privacyscreen`
-2. To remove this plugin type: `cordova plugin remove cordova-plugin-privacyscreen` or `phonegap local plugin remove cordova-plugin-privacyscreen`
+1. To add this plugin just type: `cordova plugin add cordova-plugin-privacyscreen-storyboard` or `phonegap local plugin add cordova-plugin-privacyscreen-storyboard`
+2. To remove this plugin type: `cordova plugin remove cordova-plugin-privacyscreen-storyboard` or `phonegap local plugin remove cordova-plugin-privacyscreen-storyboard`
 
 Usage:
 ------

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/holgergp/PrivacyScreenPlugin)
-
 PrivacyScreenPlugin-Storyboard
 ==================
-This is a fork of the wonderful [PrivacyScreenPlugin](https://github.com/devgeeks/PrivacyScreenPlugin)
-It's the same codebase for Android. For iOS it adds basic support for [iOS Storyboard images](https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-splashscreen/#launch-storyboard-images).
 
 Both iOS (as of iOS 7) and Android have app switchers that display a screenshot of your app.
 
@@ -19,8 +15,8 @@ Installation
 
 For Cordova 3.x.x:
 
-1. To add this plugin just type: `cordova plugin add cordova-plugin-privacyscreen-storyboard` or `phonegap local plugin add cordova-plugin-privacyscreen-storyboard`
-2. To remove this plugin type: `cordova plugin remove cordova-plugin-privacyscreen-storyboard` or `phonegap local plugin remove cordova-plugin-privacyscreen-storyboard`
+1. To add this plugin just type: `cordova plugin add cordova-plugin-privacyscreen` or `phonegap local plugin add cordova-plugin-privacyscreen`
+2. To remove this plugin type: `cordova plugin remove cordova-plugin-privacyscreen` or `phonegap local plugin remove cordova-plugin-privacyscreen`
 
 Usage:
 ------

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/holgergp/PrivacyScreenPlugin)
+
 PrivacyScreenPlugin-Storyboard
 ==================
 This is a fork of the wonderful [PrivacyScreenPlugin](https://github.com/devgeeks/PrivacyScreenPlugin)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-PrivacyScreenPlugin
+PrivacyScreenPlugin-Storyboard
 ==================
+This is a fork of the wonderful [PrivacyScreenPlugin](https://github.com/devgeeks/PrivacyScreenPlugin)
+It's the same codebase for Android. For iOS it adds basic support for [iOS Storyboard images](https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-splashscreen/#launch-storyboard-images).
 
 Both iOS (as of iOS 7) and Android have app switchers that display a screenshot of your app.
 
@@ -7,7 +9,7 @@ This is a lovely feature for most apps, but if your app displays sensitive infor
 
 This plugin flags your app so that it doesn't show your users' sensitive data in the task switcher. It sets the [FLAG_SECURE](http://developer.android.com/reference/android/view/WindowManager.LayoutParams.html#FLAG_SECURE) flag in Android (which also prevents manual screenshots from being taken) and hides the window in iOS.
 
-On iOS this plugin will try to show your splashscreen in the app switcher. It will search for splashscreens prefixed by `Default` or the value of the key `UILaunchImageFile` in your .plist file.
+On iOS this plugin will try to show your splashscreen in the app switcher. It will search for splashscreens prefixed by `Default`, the value of the key `UILaunchImageFile` in your .plist file or use the provided Storyboard image.
 If it fails to find a splashscreen for a specific device or orientation (portrait or landscape), a black screen is shown instead.
 
 Installation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "cordova-plugin-privacyscreen",
-  "version": "0.4.0",
+  "name": "cordova-plugin-privacyscreen-storyboard",
+  "version": "0.0.1",
   "description": "Secures your app from displaying a screenshot in task switchers under Android and iOS. Keeps sensitive information private.",
   "cordova": {
     "id": "cordova-plugin-privacyscreen",
@@ -21,9 +21,10 @@
     "cordova-ios"
   ],
   "author": "Tommy-Carlos Willaims <tommy@devgeeks.org>",
+  "contributors": ["Holger Grosse-Plankermann <holger.grosse-plankermann@codecentric.de>"],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/devgeeks/PrivacyScreenPlugin/issues"
+    "url": "https://github.com/holgergp/PrivacyScreenPlugin/issues"
   },
-  "homepage": "https://github.com/devgeeks/PrivacyScreenPlugin#readme"
+  "homepage": "https://github.com/holgergp/PrivacyScreenPlugin#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "cordova-plugin-privacyscreen-storyboard",
+  "name": "cordova-plugin-privacyscreen",
   "version": "0.0.1",
   "description": "Secures your app from displaying a screenshot in task switchers under Android and iOS. Keeps sensitive information private.",
   "cordova": {
-    "id": "cordova-plugin-privacyscreen-storyboard",
+    "id": "cordova-plugin-privacyscreen",
     "platforms": [
       "android",
       "ios"
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/holgergp/PrivacyScreenPlugin-Storyboard.git"
+    "url": "git+https://github.com/devgeeks/PrivacyScreenPlugin.git"
   },
   "keywords": [
     "privacy",
@@ -25,7 +25,7 @@
   "contributors": ["Holger Grosse-Plankermann <holger.grosse-plankermann@codecentric.de>"],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/holgergp/PrivacyScreenPlugin-Storyboard/issues"
+    "url": "https://github.com/devgeeks/PrivacyScreenPlugin/issues"
   },
-  "homepage": "https://github.com/holgergp/PrivacyScreenPlugin-Storyboard#readme"
+  "homepage": "https://github.com/devgeeks/PrivacyScreenPlugin#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-privacyscreen",
-  "version": "0.0.1",
+  "version": "0.4.1",
   "description": "Secures your app from displaying a screenshot in task switchers under Android and iOS. Keeps sensitive information private.",
   "cordova": {
     "id": "cordova-plugin-privacyscreen",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/holgergp/PrivacyScreenPlugin.git"
+    "url": "git+https://github.com/holgergp/PrivacyScreenPlugin-Storyboard.git"
   },
   "keywords": [
     "privacy",
@@ -25,7 +25,7 @@
   "contributors": ["Holger Grosse-Plankermann <holger.grosse-plankermann@codecentric.de>"],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/holgergp/PrivacyScreenPlugin/issues"
+    "url": "https://github.com/holgergp/PrivacyScreenPlugin-Storyboard/issues"
   },
-  "homepage": "https://github.com/holgergp/PrivacyScreenPlugin#readme"
+  "homepage": "https://github.com/holgergp/PrivacyScreenPlugin-Storyboard#readme"
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Secures your app from displaying a screenshot in task switchers under Android and iOS. Keeps sensitive information private.",
   "cordova": {
-    "id": "cordova-plugin-privacyscreen",
+    "id": "cordova-plugin-privacyscreen-storyboard",
     "platforms": [
       "android",
       "ios"
@@ -11,14 +11,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/devgeeks/PrivacyScreenPlugin.git"
+    "url": "git+https://github.com/holgergp/PrivacyScreenPlugin.git"
   },
   "keywords": [
     "privacy",
     "cordova",
     "ecosystem:cordova",
     "cordova-android",
-    "cordova-ios"
+    "cordova-ios",
+    "storyboard"
   ],
   "author": "Tommy-Carlos Willaims <tommy@devgeeks.org>",
   "contributors": ["Holger Grosse-Plankermann <holger.grosse-plankermann@codecentric.de>"],

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-privacyscreen" version="0.3.1">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-privacyscreen-storyboard" version="0.3.1">
 
-	<name>PrivacyScreenPlugin</name>
+	<name>PrivacyScreenPlugin-Storyboard</name>
 	<description>Secures your app from displaying a screenshot in task switchers under Android and iOS. Keeps sensitive information private.</description>
 	<license>MIT</license>
 	<platform name="android">

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-privacyscreen" version="0.3.1">
 
-	<name>PrivacyScreenPlugin-Storyboard</name>
+	<name>PrivacyScreenPlugin</name>
 	<description>Secures your app from displaying a screenshot in task switchers under Android and iOS. Keeps sensitive information private.</description>
 	<license>MIT</license>
 	<platform name="android">

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-privacyscreen-storyboard" version="0.3.1">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-privacyscreen" version="0.3.1">
 
 	<name>PrivacyScreenPlugin-Storyboard</name>
 	<description>Secures your app from displaying a screenshot in task switchers under Android and iOS. Keeps sensitive information private.</description>

--- a/src/ios/PrivacyScreenPlugin.m
+++ b/src/ios/PrivacyScreenPlugin.m
@@ -75,8 +75,6 @@ static UIImageView *imageView;
   // this is appropriate for detecting the runtime screen environment
   device.iPhone6 = (device.iPhone && limit == 667.0);
   device.iPhone6Plus = (device.iPhone && limit == 736.0);
-  device.iPhoneX = (device.iPhone && limit >= 812.0);
-
   
   return device;
 }

--- a/src/ios/PrivacyScreenPlugin.m
+++ b/src/ios/PrivacyScreenPlugin.m
@@ -40,6 +40,10 @@ static UIImageView *imageView;
     imageView = [[UIImageView alloc]initWithFrame:[self.viewController.view bounds]];
     [imageView setImage:splash];
     
+    // [imageView setContentMode:UIViewContentModeCenter]; // custom
+    //[imageView setContentMode:UIViewContentModeScaleAspectFit]; // custom
+    [imageView setContentMode:UIViewContentModeScaleAspectFill]; // custom
+    
     #ifdef __CORDOVA_4_0_0
         [[UIApplication sharedApplication].keyWindow addSubview:imageView];
     #else

--- a/src/ios/PrivacyScreenPlugin.m
+++ b/src/ios/PrivacyScreenPlugin.m
@@ -74,6 +74,16 @@ static UIImageView *imageView;
   return device;
 }
 
+- (BOOL) isUsingCDVLaunchScreen {
+    NSString* launchStoryboardName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UILaunchStoryboardName"];
+    if (launchStoryboardName) {
+        return ([launchStoryboardName isEqualToString:@"CDVLaunchScreen"]);
+    } else {
+        return NO;
+    }
+}
+
+
 - (NSString*)getImageName:(UIInterfaceOrientation)currentOrientation delegate:(id<CDVScreenOrientationDelegate>)orientationDelegate device:(CDV_iOSDevice)device
 {
   // Use UILaunchImageFile if specified in plist.  Otherwise, use Default.
@@ -81,6 +91,13 @@ static UIImageView *imageView;
   
   NSUInteger supportedOrientations = [orientationDelegate supportedInterfaceOrientations];
   
+  // detect if we are using CB-9762 Launch Storyboard; if so, return the associated image instead
+  if ([self isUsingCDVLaunchScreen]) {
+      imageName = @"LaunchStoryboard";
+      return imageName;
+  }
+
+
   // Checks to see if the developer has locked the orientation to use only one of Portrait or Landscape
   BOOL supportsLandscape = (supportedOrientations & UIInterfaceOrientationMaskLandscape);
   BOOL supportsPortrait = (supportedOrientations & UIInterfaceOrientationMaskPortrait || supportedOrientations & UIInterfaceOrientationMaskPortraitUpsideDown);

--- a/src/ios/PrivacyScreenPlugin.m
+++ b/src/ios/PrivacyScreenPlugin.m
@@ -40,9 +40,10 @@ static UIImageView *imageView;
     imageView = [[UIImageView alloc]initWithFrame:[self.viewController.view bounds]];
     [imageView setImage:splash];
     
-    // [imageView setContentMode:UIViewContentModeCenter]; // custom
-    //[imageView setContentMode:UIViewContentModeScaleAspectFit]; // custom
-    [imageView setContentMode:UIViewContentModeScaleAspectFill]; // custom
+    if ([self isUsingCDVLaunchScreen]) {
+        // launch screen expects the image to be scaled using AspectFill.
+        imageView.contentMode = UIViewContentModeScaleAspectFill;
+    }
     
     #ifdef __CORDOVA_4_0_0
         [[UIApplication sharedApplication].keyWindow addSubview:imageView];
@@ -74,6 +75,8 @@ static UIImageView *imageView;
   // this is appropriate for detecting the runtime screen environment
   device.iPhone6 = (device.iPhone && limit == 667.0);
   device.iPhone6Plus = (device.iPhone && limit == 736.0);
+  device.iPhoneX = (device.iPhone && limit >= 812.0);
+
   
   return device;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds basic functionality to make use of storyboard images on iOS. Apple will sunset support for exact image sizes on June 30th [Link](https://developer.apple.com/news/?id=03262020b)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #51 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This plugin will not supposedly not work as expected due to Apples new guideline. Please see the link above.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I already have this change in use using a [fork](https://www.npmjs.com/package/cordova-plugin-privacyscreen-storyboard) of this plugin: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
